### PR TITLE
Add touchstart + touchend + touchcancel

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ var commonEvents = [
     "blur", "change", "click",  "contextmenu", "dblclick",
     "error","focus", "focusin", "focusout", "input", "keydown",
     "keypress", "keyup", "load", "mousedown", "mouseup",
-    "resize", "scroll", "select", "submit", "unload"
+    "resize", "scroll", "select", "submit", "touchcancel",
+    "touchend", "touchstart", "unload"
 ]
 
 /*  Delegator is a thin wrapper around a singleton `DOMDelegator`


### PR DESCRIPTION
I don't think we want touchleave on by default.

"mouseleave mouseenter touchleave touchstart"

Those all sound like high volume events that should
be optin rather then globally defaulted.

cc @jxson
