### PR TITLE
move handle methods off the prototype

### DIFF
--- a/dom-delegator.js
+++ b/dom-delegator.js
@@ -22,7 +22,7 @@ function DOMDelegator(document) {
 DOMDelegator.prototype.addEventListener = addEvent
 DOMDelegator.prototype.removeEventListener = removeEvent
 
-DOMDelegator.prototype.allocateHandle =
+DOMDelegator.allocateHandle =
     function allocateHandle(func) {
         var handle = new Handle()
 
@@ -31,7 +31,7 @@ DOMDelegator.prototype.allocateHandle =
         return handle
     }
 
-DOMDelegator.prototype.transformHandle =
+DOMDelegator.transformHandle =
     function transformHandle(handle, lambda) {
         var func = HANDLER_STORE(handle).func
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var commonEvents = [
     Only one DOMDelegator should exist because we do not want
         duplicate event listeners bound to the DOM.
 
-    `Delegator` will also `listenTo()` all events unless 
+    `Delegator` will also `listenTo()` all events unless
         every caller opts out of it
 */
 module.exports = Delegator
@@ -53,4 +53,5 @@ function Delegator(opts) {
     return delegator
 }
 
-
+Delegator.allocateHandle = DOMDelegator.allocateHandle;
+Delegator.transformHandle = DOMDelegator.transformHandle;

--- a/test/dom-handle.js
+++ b/test/dom-handle.js
@@ -13,7 +13,7 @@ test("can listen to handles", function (assert) {
 
     var results = []
 
-    var handle = d.allocateHandle(function (ev) {
+    var handle = Delegator.allocateHandle(function (ev) {
         results.push(ev)
     })
     d.addEventListener(elem, "click", handle)
@@ -34,11 +34,11 @@ test("can transform a handle", function (assert) {
 
     var results = []
 
-    var handle = d.allocateHandle(function (ev) {
+    var handle = Delegator.allocateHandle(function (ev) {
         results.push(ev)
     })
 
-    var handle2 = d.transformHandle(handle, function (ev) {
+    var handle2 = Delegator.transformHandle(handle, function (ev) {
         return { foo: "bar", type: ev.type }
     })
     d.addEventListener(elem, "click", handle2)
@@ -58,11 +58,11 @@ test("transform handle respects falsey", function (assert) {
 
     var results = []
 
-    var handle = d.allocateHandle(function (ev) {
+    var handle = Delegator.allocateHandle(function (ev) {
         results.push(ev)
     })
 
-    var handle2 = d.transformHandle(handle, function (ev) {
+    var handle2 = Delegator.transformHandle(handle, function (ev) {
         return null
     })
     d.addEventListener(elem, "click", handle2)


### PR DESCRIPTION
by moving `allocateHandles` and `transformHandles` off `DomDelegator.prototype` then you don't need to create a delegator to create a handle or a transform
