### PR TITLE
don't die when the event target is window

### DIFF
--- a/dom-delegator.js
+++ b/dom-delegator.js
@@ -145,7 +145,7 @@ function findAndInvokeListeners(elem, ev, eventName) {
 
 function getListener(target, type) {
     // terminate recursion if parent is `null`
-    if (target === null) {
+    if (target === null || typeof target === "undefined") {
         return null
     }
 


### PR DESCRIPTION
when you scroll a page in ios in a way that hides the navigation and tab bars, it causes a resize to fire on `documentElement` even though `window` is the target (demo at http://jsbin.com/cuwikexefu).  `window.parentNode` is `undefined` (rather than `null`) and so it means that `getListener` ends up calling `EvStore` with an `undefined` `target`.

this PR causes `getListener` to terminate with an `undefined` `target`.