### PR TITLE
cuid recent update breaks browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "cuid": "^1.2.4",
+    "cuid": "~1.2.4",
     "ev-store": "^7.0.0",
     "global": "^4.2.1",
     "individual": "^2.0.0",


### PR DESCRIPTION
The cuid package was updated to 1.3.0 today with some kind of breaking change which it breaks the ability to browserify.  I am running mercury.js for my build.  This PR changes cuid dependency from caret to tilde so we can take the time to figure out why cuid breaks.

Would you accept this PR and publish a patch version of dom-delegator please?

```
events.js:141
      throw er; // Unhandled 'error' event
            ^
Error: Cannot find module 'cuid' from '/Users/tommy/src/cbanc/cbw/node_modules/mercury/node_modules/dom-delegator'
    at /Users/tommy/src/cbanc/cbw/node_modules/browserify/node_modules/resolve/lib/async.js:46:17
    at process (/Users/tommy/src/cbanc/cbw/node_modules/browserify/node_modules/resolve/lib/async.js:173:43)
    at ondir (/Users/tommy/src/cbanc/cbw/node_modules/browserify/node_modules/resolve/lib/async.js:188:17)
    at load (/Users/tommy/src/cbanc/cbw/node_modules/browserify/node_modules/resolve/lib/async.js:69:43)
    at onex (/Users/tommy/src/cbanc/cbw/node_modules/browserify/node_modules/resolve/lib/async.js:92:31)
    at /Users/tommy/src/cbanc/cbw/node_modules/browserify/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:82:15)
```
